### PR TITLE
fix: :bug: Add rake task to keep reachoutt website heroku dyno from s…

### DIFF
--- a/reachoutt_backend/app/controllers/api/reachouts_controller.rb
+++ b/reachoutt_backend/app/controllers/api/reachouts_controller.rb
@@ -27,11 +27,11 @@ class Api::ReachoutsController < ApplicationController
 ReachOutt will remind you to get in touch with #{@reachout.contact.first_name} #{@reachout.friendly_frequency(@reachout.frequency)}."
       
       # Checks if reachout has a topic and if so gives a topic based reachout sudgestion - testing code. Only sent on reachout frequency texts
-#       topic_response = @reachout.get_topic_data
-#       if topic_response
-#         message = client.messages.create from: '12014236603', to: "#{@reachout.user.phone_number}", body: "Hey #{@reachout.user.first_name}! You and #{@reachout.contact.first_name} both like #{@reachout.topic}.
-# #{@reachout.get_topic_data}"
-#       end
+      topic_response = @reachout.get_topic_data
+      if topic_response
+        message = client.messages.create from: '12014236603', to: "#{@reachout.user.phone_number}", body: "Hey #{@reachout.user.first_name}! You and #{@reachout.contact.first_name} both like #{@reachout.topic}.
+#{@reachout.get_topic_data}"
+      end
 
       # Create Rufus (cron) job to send a reminder text to reachout every frequency
       s = Rufus::Scheduler.singleton

--- a/reachoutt_backend/lib/tasks/scheduler.rake
+++ b/reachoutt_backend/lib/tasks/scheduler.rake
@@ -1,0 +1,5 @@
+desc "Keep heroku reachoutt awake"
+task :call_reachoutt => :environment do
+  uri = URI.parse("http://www.reachoutt.com/")
+  Net::HTTP.get(uri)
+end


### PR DESCRIPTION
…leeping

heroku has dynos sleep by default after 1 hour of inactivity which causes all of the rufus scheudled jobs to go away and stop working. this prevents that